### PR TITLE
Add an ID to the re-frisk debugger so it can be targeted by CSS

### DIFF
--- a/src/re_frisk/devtool.cljs
+++ b/src/re_frisk/devtool.cljs
@@ -57,7 +57,7 @@
         doc js/document]
     (aset w "onunload" on-window-unload)
     (swap! data/deb-data assoc :deb-win-closed? false :doc d :win w :app app)
-    (reagent/render [:div  {:style {:height "100%"}}
+    (reagent/render [:div {:id "re-frisk-debugger" :style {:height "100%"}}
                      [:input {:type "file" :id "json-file-field" :on-change json-on-change :style {:display "none"}}]
                      [:div  {:style {:height "100%"}}
                       (if (and re-frame? (not= (:events? (:prefs @data/deb-data)) false))


### PR DESCRIPTION
![](https://puu.sh/yyRbN/e51f326529.png)

In my case I've got a global `color: @light-green` applied, which applies to the re-frisk panel, and makes it impossible to read. With an ID I can add styling to change the re-frisk CSS easily :)