### PR TITLE
Add delta algorithm for structures

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -55,7 +55,8 @@
 
   :profiles {:dev {:dependencies [[binaryage/devtools "0.7.2"]
                                   [figwheel-sidecar "0.5.4-7"]
-                                  [com.cemerick/piggieback "0.2.1"]]
+                                  [com.cemerick/piggieback "0.2.1"]
+                                  [org.clojure/test.check "0.9.0"]]
                    ;; need to add dev source path here to get user.clj loaded
                    :source-paths ["src" "dev"]
                    ;; for CIDER

--- a/src/re_frisk/delta.cljc
+++ b/src/re_frisk/delta.cljc
@@ -1,0 +1,94 @@
+(ns re-frisk.delta
+  (:require [clojure.set :as set])
+  (:refer-clojure :exclude [apply]))
+
+;; diff description:
+;; [:replace x] -- replace current node with x
+;; [:set #{1 2} #{3 4}] -- add 1 2 and to the current node, remove 3 4
+;; [:map {1 2} #{3 4} {5 Z}] -- add (1 2) pair to current node, remove 3 4,
+;;   apply patch Z to the value of key 5
+;; [:seq 0 {6 Z}] -- apply patch Z to the value of key 6
+;; [:seq [5 6] {6 Z}] -- add values 5 and 6
+;; [:seq 3 {6 Z}] -- pop the last 3 values,
+;;   apply patch Z to the value of key 6
+
+(declare delta)
+
+;; Don't pass empty collections around, replace them with nulls
+(defn nullify [a]
+  (if (empty? a) nil a))
+
+(defn- delta-set [a b]
+  [:set (nullify (set/difference b a)) (nullify (set/difference a b))])
+
+(defn- ff [a b k]
+  (when (not= (a k) (b k))
+    [k (delta (a k) (b k))]))
+
+(defn- delta-map-vals [a b ks]
+  (nullify (into {} (filter some? (map #(ff a b %) ks)))))
+
+(defn- delta-map [a b]
+  (let [akeys (set (keys a))
+        bkeys (set (keys b))
+        common (set/intersection akeys bkeys)
+        add (set/difference bkeys akeys)
+        remove (nullify (set/difference akeys bkeys))]
+    [:map (nullify (select-keys b add)) remove (delta-map-vals a b common)]))
+
+(defn- delta-seq-vals [n a b]
+  (let [items (map vector (range) a b)]
+    (->> items
+         (map (fn [[i a b]] (when (not= a b) [i (delta a b)])))
+         (filter some?)
+         (into {}))))
+
+(defn- delta-vec [a b]
+  (let [ca (count a)
+        cb (count b)
+        mc (min ca cb)
+        tail (if (<= cb ca) (- ca cb) (subvec b ca))]
+    [:vec tail (nullify (delta-seq-vals mc a b))]))
+
+(defn delta [a b]
+  (cond
+    (= a b) nil
+    (and (map? a) (map? b)) (delta-map a b)
+    (and (set? a) (set? b)) (delta-set a b)
+    (and (list? a) (list? b)) [:replace b]
+    (and (vector? a) (vector? b)) (delta-vec a b)
+    :else [:replace b]))
+
+(declare apply)
+
+(defn- apply-set [a [add remove]]
+  (set/difference (set/union a add) remove))
+
+;; [1 2 3] {1 [:set 7]} -> [1 7 3]
+(defn- apply-vec-changes [a changes]
+  (reduce (fn [a [k ch]] (update-in a [k] #(apply % ch))) a changes))
+
+(defn- apply-vec [a [tail changes]]
+  (let [h (apply-vec-changes a changes)]
+    (cond
+      (= 0 tail) h
+      (integer? tail) (subvec h 0 (- (count h) tail))
+      :else (vec (concat h tail)))))
+
+;; {1 2 3 4} {3 [:set 6]} -> {1 2 3 6}
+(defn apply-map-changes [a changes]
+  (reduce (fn [a [k ch]] (update-in a [k] #(apply % ch))) a changes))
+
+(defn- apply-map [a [keys-add keys-remove changes]]
+  (as-> a A
+      (apply-map-changes A changes)
+      (merge keys-add A)
+      (clojure.core/apply dissoc A keys-remove)))
+
+(defn apply [a patch]
+  (case (first patch)
+    nil a
+    :replace (second patch)
+    :set (apply-set a (rest patch))
+    :vec (apply-vec a (rest patch))
+    :map (apply-map a (rest patch))))

--- a/test/re_frisk/delta_test.cljs
+++ b/test/re_frisk/delta_test.cljs
@@ -1,0 +1,21 @@
+(ns re-frisk.delta-test
+  (:require [clojure.test.check.clojure-test :as ct :include-macros true]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check]
+            [clojure.test.check.properties :as prop :include-macros true]
+            [re-frisk.delta :as sut]))
+
+;; NaNs make everything hard, and break clojure.core/=
+(defn nonans [a]
+  (cond
+    (set? a) (every? nonans a)
+    (sequential? a) (every? nonans a)
+    (associative? a) (and (every? nonans (keys a)) (every? nonans (vals a)))
+    :else (not (js/Number.isNaN a))))
+
+(def any-no-nan (gen/such-that nonans gen/any))
+
+(ct/defspec delta-patch-is-identity
+  {:num-tests 10000 :max-size 15}
+  (prop/for-all [a any-no-nan b any-no-nan]
+                (= (sut/apply a (sut/delta a b)) b)))

--- a/test/re_frisk/test_runner.cljs
+++ b/test/re_frisk/test_runner.cljs
@@ -1,5 +1,7 @@
 (ns re-frisk.test-runner
   (:require [doo.runner :refer-macros [doo-tests]]
-            [re-frisk.diff-test]))
+            [re-frisk.diff-test]
+            [re-frisk.delta-test]))
 
-(doo-tests 're-frisk.diff-test)
+(doo-tests 're-frisk.delta-test
+           're-frisk.diff-test)


### PR DESCRIPTION
Part of flexsurfer/re-frisk-remote#3.

Added delta algorithm is used by `re-frisk-remote` to produce deltas of various data structures, and `re-frisk-sidecar` to apply deltas back to obtain full data.