### PR TITLE
Support frisk.preload for reagent-only use case

### DIFF
--- a/dev/re_frisk/reagent_demo.cljs
+++ b/dev/re_frisk/reagent_demo.cljs
@@ -1,6 +1,6 @@
 (ns re-frisk.reagent-demo
   (:require [reagent.core :as r]
-            [re-frisk.core :refer [enable-frisk! add-data add-in-data]]))
+            [re-frisk.core :refer [add-data add-in-data]]))
 
 (defn atom-input [value]
   [:input {:type "text"
@@ -20,6 +20,5 @@
 
 (defn ^:export run
   []
-  (enable-frisk!)
   (r/render [shared-state]
             (js/document.getElementById "app")))

--- a/project.clj
+++ b/project.clj
@@ -4,18 +4,18 @@
   :license {:name "MIT"
             :url "https://opensource.org/licenses/MIT"}
 
-  :min-lein-version "2.6.1"
+  :min-lein-version "2.9.0"
 
-  :dependencies [[org.clojure/clojure "1.9.0-RC1"]
-                 [org.clojure/clojurescript "1.9.946"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [org.clojure/clojurescript "1.10.520"]
                  [reagent "0.7.0"]
                  [re-frame "0.10.1"]
                  [re-frisk-shell "0.5.2"]
-                 [com.cognitect/transit-cljs "0.8.243"]]
+                 [com.cognitect/transit-cljs "0.8.256"]]
 
   :plugins [[lein-cljsbuild "1.1.7" :exclusions [[org.clojure/clojure]]]
-            [lein-figwheel "0.5.13"]
-            [lein-doo "0.1.8"]]
+            [lein-figwheel "0.5.18"]
+            [lein-doo "0.1.11"]]
 
   :source-paths ["src"]
 
@@ -24,8 +24,8 @@
   :cljsbuild {:builds
               [{:id "dev"
                 :source-paths ["src" "dev"]
-                :figwheel {:on-jsload "re-frisk.demo/on-js-reload"}
-
+                :figwheel {:on-jsload "re-frisk.demo/on-js-reload"
+                           :open-urls ["http://localhost:3449/index.html"]}
                 :compiler {:main re-frisk.demo
                            :asset-path "js/compiled/out/re-frisk"
                            :output-to "resources/re-frisk/js/compiled/re_frisk.js"
@@ -55,16 +55,8 @@
   :doo {:build "test"
         :alias {:default [:node]}}
 
-  :profiles {:dev {:dependencies [[binaryage/devtools "0.7.2"]
-                                  [figwheel-sidecar "0.5.4-7"]
-                                  [com.cemerick/piggieback "0.2.1"]
+  :profiles {:dev {:dependencies [[binaryage/devtools "0.9.10"]
+                                  [figwheel-sidecar "0.5.18"]
                                   [org.clojure/test.check "0.9.0"]]
                    ;; need to add dev source path here to get user.clj loaded
-                   :source-paths ["src" "dev"]
-                   ;; for CIDER
-                   ;; :plugins [[cider/cider-nrepl "0.12.0"]]
-                   :repl-options {; for nREPL dev you really need to limit output
-                                  :init (set! *print-length* 50)
-                                  :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}})
-
-
+                   :source-paths ["src" "dev"]}})

--- a/project.clj
+++ b/project.clj
@@ -36,13 +36,15 @@
                            :external-config {:re-frisk {:enabled true}}}}
                {:id "reagent"
                 :source-paths ["src" "dev"]
-                :figwheel {:on-jsload "re-frisk.reagent_demo/on-js-reload"}
+                :figwheel {:on-jsload "re-frisk.reagent_demo/on-js-reload"
+                           :open-urls ["http://localhost:3449/reagent.html"]}
                 :compiler {:main re-frisk.reagent-demo
                            :asset-path "js/compiled/out/reagent"
                            :output-to "resources/re-frisk/js/compiled/re_frisk_reagent.js"
                            :output-dir "resources/re-frisk/js/compiled/out/reagent"
                            :source-map-timestamp true
-                           :preloads [devtools.preload]}}
+                           :preloads [devtools.preload
+                                      frisk.preload]}}
                {:id "test"
                 :source-paths ["src" "dev" "test"]
                 :compiler {:main re-frisk.test-runner

--- a/src/frisk/preload.cljs
+++ b/src/frisk/preload.cljs
@@ -1,0 +1,4 @@
+(ns frisk.preload
+  (:require [re-frisk.core :refer [enable-frisk!]]))
+
+(enable-frisk!)


### PR DESCRIPTION
I want to `(enable-frisk!)` for development builds of my reagent project via the `project.clj` in a fashion identical to the `re-frisk.preload` using `frisk.preload`. 

Since I'm using a more recent toolchain, I thought I'd bump dependencies and tooling requirements to align with more recent `cider 0.20.0` on ward.

I'm happy to remove the dependency upgrades if they're surplus to reqs or otherwise undesirable.  