### PR TITLE
updates for reagent 0.10.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,15 +6,15 @@
 
   :min-lein-version "2.9.0"
 
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [org.clojure/clojurescript "1.10.520"]
-                 [reagent "0.7.0"]
-                 [re-frame "0.10.1"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/clojurescript "1.10.597"]
+                 [reagent "0.10.0"]
+                 [re-frame "0.12.0"]
                  [re-frisk-shell "0.5.2"]
                  [com.cognitect/transit-cljs "0.8.256"]]
 
   :plugins [[lein-cljsbuild "1.1.7" :exclusions [[org.clojure/clojure]]]
-            [lein-figwheel "0.5.18"]
+            [lein-figwheel "0.5.19"]
             [lein-doo "0.1.11"]]
 
   :source-paths ["src"]
@@ -55,8 +55,8 @@
   :doo {:build "test"
         :alias {:default [:node]}}
 
-  :profiles {:dev {:dependencies [[binaryage/devtools "0.9.10"]
-                                  [figwheel-sidecar "0.5.18"]
-                                  [org.clojure/test.check "0.9.0"]]
+  :profiles {:dev {:dependencies [[binaryage/devtools "1.0.0"]
+                                  [figwheel-sidecar "0.5.19"]
+                                  [org.clojure/test.check "1.0.0"]]
                    ;; need to add dev source path here to get user.clj loaded
                    :source-paths ["src" "dev"]}})

--- a/src/re_frisk/core.cljs
+++ b/src/re_frisk/core.cljs
@@ -1,5 +1,6 @@
 (ns re-frisk.core
-  (:require [reagent.core :as reagent]
+  (:require [reagent.dom :as rdom]
+            [reagent.core :as reagent]
             [reagent.ratom :refer-macros [reaction]]
             [re-frame.core :refer [subscribe] :as re-frame]
             [re-frame.db :refer [app-db]]
@@ -37,7 +38,7 @@
              ;;TODO https://github.com/flexsurfer/re-frisk/issues/28
              (.alert (:win @data/deb-data) "Application has been closed or refreshed. Debugger has been stopped!")))
 
-    (reagent/render [devtool/re-frisk-shell params] div)))
+    (rdom/render [devtool/re-frisk-shell params] div)))
 
 
 ;;ENTRY

--- a/src/re_frisk/devtool.cljs
+++ b/src/re_frisk/devtool.cljs
@@ -1,6 +1,7 @@
 (ns re-frisk.devtool
   (:require-macros [re-frisk.slurp :refer [slurp]])
-  (:require [reagent.core :as reagent]
+  (:require [reagent.dom :as rdom]
+            [reagent.core :as reagent]
             [reagent.dom :as reagent-dom]
             [re-frisk.drag :as drag]
             [re-frame.core :refer [dispatch]]
@@ -57,7 +58,7 @@
         doc js/document]
     (goog.object/set w "onunload" on-window-unload)
     (swap! data/deb-data assoc :deb-win-closed? false :doc d :win w :app app)
-    (reagent/render [:div {:id "re-frisk-debugger" :style {:height "100%"}}
+    (rdom/render [:div {:id "re-frisk-debugger" :style {:height "100%"}}
                      [:input {:type "file" :id "json-file-field" :on-change json-on-change :style {:display "none"}}]
                      [:div  {:style {:height "100%"}}
                       (if (and re-frame? (not= (:events? (:prefs @data/deb-data)) false))


### PR DESCRIPTION
Reagent 0.10.0 changed the API to split the `render` function out from `reagent.core` to `reagent.dom`.