### PR TITLE
Including protocol in server start log

### DIFF
--- a/src/re_frisk_remote/server/main.clj
+++ b/src/re_frisk_remote/server/main.clj
@@ -108,4 +108,4 @@
                          :access-control-allow-credentials "true"))
                     {:port port
                      :max-ws 100194304})
-    (println (str "re-frisk server has been started at localhost:" port))))
+    (println (str "re-frisk - server has been started at http://localhost:" port))))


### PR DESCRIPTION
This is a tiny change, but will make our lives easier. It adds the `http://` protocol to the log output so it can be parsed as an URL in terminals such as iTerm2.

I've also took the freedom to bring the format in line with the output of shadow-cljs. For context, we're starting re-frisk server as part of our `shadow_build.clj` which will produce the following logs after this change.

```
shadow-cljs - HTTP server available at http://localhost:9666
shadow-cljs - server version: 2.12.1 running at http://localhost:9630
shadow-cljs - nREPL server started on port 7888
re-frisk - server has been started at http://localhost:4567
```

Thanks for considering :)