### PR TITLE
Fix issue with trying to delta reitit route tables

### DIFF
--- a/src/re_frisk_remote/delta/delta.cljc
+++ b/src/re_frisk_remote/delta/delta.cljc
@@ -22,8 +22,8 @@
   [:set (nullify (set/difference b a)) (nullify (set/difference a b))])
 
 (defn- ff [a b k]
-  (when (not= (a k) (b k))
-    [k (delta (a k) (b k))]))
+  (when (not= (get a k) (get b k))
+    [k (delta (get a k) (get b k))]))
 
 (defn- delta-map-vals [a b ks]
   (nullify (into {} (filter some? (map #(ff a b %) ks)))))


### PR DESCRIPTION
I'm storing reitit routes in the re-frame db, and they're causing issues. I _think_ they implement the IMap protocol, but not the Ifn protocol, so `map?` returns true, but when trying to use them as a function they fail.

The error message is a particularly weird `a.call is not a function` in ff.

This makes delta use an explicit `get` instead of an implicit map function call, which fixes the issue.