### PR TITLE
Position open panel from right corner of the viewport always

### DIFF
--- a/re-frisk/src/re_frisk/db.cljs
+++ b/re-frisk/src/re_frisk/db.cljs
@@ -9,8 +9,8 @@
 
    ;External window opened
    :ext-win-opened?    false
-   ;Latest opened position
-   :latest-left        600
+   ;Latest opened width
+   :latest-width       600
    ;Options provided by user {:ext_height :ext_width :events?}
    :opts               nil
 

--- a/re-frisk/src/re_frisk/ui.cljs
+++ b/re-frisk/src/re_frisk/ui.cljs
@@ -50,12 +50,12 @@
 
 (defn handle-toggle []
   (let [width (or (utils/normalize-draggable (:width @drag/draggable))
-                  30)]
+                  0)]
     (when-not (utils/closed? width)
       (swap! db/tool-state assoc :latest-width width))
     (swap! drag/draggable assoc :width (if (utils/closed? width)
                                          (:latest-width @db/tool-state)
-                                         30))))
+                                         0))))
 
 (defn handle-keydown [e]
   (let [input-elements #{"INPUT" "SELECT" "TEXTAREA"}
@@ -74,7 +74,7 @@
     (fn []
       (when-not @ext-opened?
         (let [width (or (utils/normalize-draggable (:width @drag/draggable))
-                        30)]
+                        0)]
           [:div {:style (style/inner-view-container width (:offset @drag/draggable))}
            (when-not (and hidden (utils/closed? width))
              [:div {:style {:display :flex :flex-direction :column :opacity 0.3}}

--- a/re-frisk/src/re_frisk/ui.cljs
+++ b/re-frisk/src/re_frisk/ui.cljs
@@ -49,12 +49,13 @@
         [ui.views/main-view re-frame-data db/tool-state doc]]))))
 
 (defn handle-toggle []
-  (let [left (or (utils/normalize-draggable (:x @drag/draggable))
-                 (- js/window.innerWidth 30))]
-    (when-not (utils/closed? left)
-      (swap! db/tool-state assoc :latest-left (- js/window.innerWidth left)))
-    (swap! drag/draggable assoc :x (- js/window.innerWidth
-                                      (if (utils/closed? left) (:latest-left @db/tool-state) 30)))))
+  (let [width (or (utils/normalize-draggable (:width @drag/draggable))
+                  30)]
+    (when-not (utils/closed? width)
+      (swap! db/tool-state assoc :latest-width width))
+    (swap! drag/draggable assoc :width (if (utils/closed? width)
+                                         (:latest-width @db/tool-state)
+                                         30))))
 
 (defn handle-keydown [e]
   (let [input-elements #{"INPUT" "SELECT" "TEXTAREA"}
@@ -72,10 +73,10 @@
         hidden (get-in  @db/tool-state [:opts :hidden])]
     (fn []
       (when-not @ext-opened?
-        (let [left (or (utils/normalize-draggable (:x @drag/draggable))
-                       (- js/window.innerWidth 30))]
-          [:div {:style (style/inner-view-container left (:offset @drag/draggable))}
-           (when-not (and hidden (utils/closed? left))
+        (let [width (or (utils/normalize-draggable (:width @drag/draggable))
+                        30)]
+          [:div {:style (style/inner-view-container width (:offset @drag/draggable))}
+           (when-not (and hidden (utils/closed? width))
              [:div {:style {:display :flex :flex-direction :column :opacity 0.3}}
               [:div {:style    style/external-button
                      :on-click (open-debugger-window re-frame-data)}
@@ -83,10 +84,10 @@
               [:div {:style {:display :flex :flex 1 :justify-content :center :flex-direction :column}}
                [:div {:style    style/external-button
                       :on-click handle-toggle}
-                (if (utils/closed? left) "\u2b60" "\u2b62")]
+                (if (utils/closed? width) "\u2b60" "\u2b62")]
                [:div {:style         style/dragg-button
                       :on-mouse-down drag/mouse-down-handler}]]])
-           (when-not (utils/closed? left)
+           (when-not (utils/closed? width)
              [:div {:style {:display :flex :flex 1 :width "100%" :height "100%"}}
               [:iframe {:id      "re-frisk-iframe" :src-doc external-hml/html-doc :width "100%" :height "100%"
                         :style   (if (:offset @drag/draggable) {:pointer-events :none} {:pointer-events :all})

--- a/re-frisk/src/re_frisk/ui/components/drag.cljs
+++ b/re-frisk/src/re_frisk/ui/components/drag.cljs
@@ -6,13 +6,16 @@
 (defonce draggable (reagent/atom {}))
 
 (defn mouse-move-handler [evt]
-  (swap! draggable assoc :x (- (.-clientX evt) (:offset @draggable))))
+  (swap! draggable (fn [{:keys [offset] :as state}]
+                     (assoc state :width (+ (- (.-innerWidth js/window) (.-clientX evt)) offset)))))
 
 (defn mouse-up-handler [evt]
     (goog-events/unlisten js/window EventType.MOUSEMOVE mouse-move-handler)
     (swap! draggable dissoc :offset))
 
 (defn mouse-down-handler [evt]
+  ;; Offset is the distance from pointer to the left corner of the re-frisk panel,
+  ;; it is used on the move handler to get the full width of the panel from move coordinate.
   (swap! draggable assoc :offset (- (.-clientX evt) (.-left (.getBoundingClientRect (.-target evt)))))
   (goog-events/listen js/window EventType.MOUSEMOVE mouse-move-handler))
 

--- a/re-frisk/src/re_frisk/ui/components/drag.cljs
+++ b/re-frisk/src/re_frisk/ui/components/drag.cljs
@@ -7,16 +7,19 @@
 
 (defn mouse-move-handler [evt]
   (swap! draggable (fn [{:keys [offset] :as state}]
-                     (assoc state :width (+ (- (.-innerWidth js/window) (.-clientX evt)) offset)))))
+                     (assoc state :width (- (.-innerWidth js/window)
+                                            (.-clientX evt)
+                                            ;; Toggle button is 30px outside of the panel.
+                                            (+ 30 offset))))))
 
 (defn mouse-up-handler [evt]
     (goog-events/unlisten js/window EventType.MOUSEMOVE mouse-move-handler)
     (swap! draggable dissoc :offset))
 
 (defn mouse-down-handler [evt]
-  ;; Offset is the distance from pointer to the left corner of the re-frisk panel,
+  ;; Offset is the distance from pointer to the left corner of the toggle button,
   ;; it is used on the move handler to get the full width of the panel from move coordinate.
-  (swap! draggable assoc :offset (- (.-clientX evt) (.-left (.getBoundingClientRect (.-target evt)))))
+  (swap! draggable assoc :offset (- (.-left (.getBoundingClientRect (.-target evt))) (.-clientX evt)))
   (goog-events/listen js/window EventType.MOUSEMOVE mouse-move-handler))
 
 (goog-events/listen js/window EventType.MOUSEUP mouse-up-handler)

--- a/re-frisk/src/re_frisk/ui/style.cljs
+++ b/re-frisk/src/re_frisk/ui/style.cljs
@@ -1,7 +1,7 @@
 (ns re-frisk.ui.style
   (:require [re-frisk.utils :as utils]))
 
-(defn inner-view-container [left dragging?]
+(defn inner-view-container [width dragging?]
   (merge {:position       :fixed
           :top            0
           :bottom         0
@@ -10,9 +10,9 @@
           :pointer-events :all
           :flex-direction :row
           :flex           1
-          :left           left}
-         (when (and (not dragging?) (not (utils/closed? left)))
-           {:transition "left 0.5s"})))
+          :width          (str width "px")}
+         (when (and (not dragging?) (not (utils/closed? width)))
+           {:transition "width 0.5s"})))
 
 (def external-button
   {:width                     30

--- a/re-frisk/src/re_frisk/ui/style.cljs
+++ b/re-frisk/src/re_frisk/ui/style.cljs
@@ -15,7 +15,8 @@
            {:transition "width 0.5s"})))
 
 (def external-button
-  {:width                     30
+  {:margin-left -30
+   :width                     30
    :height                    30
    :background-color          "#df691a"
    :color                     :white
@@ -27,7 +28,8 @@
    :justify-content           :center})
 
 (def dragg-button
-  {:width                     30
+  {:margin-left -30
+   :width                     30
    :height                    60
    :background-color          "#df691a"
    :display                   :flex

--- a/re-frisk/src/re_frisk/utils.cljs
+++ b/re-frisk/src/re_frisk/utils.cljs
@@ -44,12 +44,12 @@
 
 (defn normalize-draggable [x]
   (when x
-    (cond (< x 30) 30
+    (cond (< x 0) 0
           (> x (- js/window.innerWidth 30)) (- js/window.innerWidth 30)
           :else x)))
 
 (defn closed? [width]
-  (= 30 width))
+  (= 0 width))
 
 (defn str-ms [value]
   (when-not (string/blank? value)

--- a/re-frisk/src/re_frisk/utils.cljs
+++ b/re-frisk/src/re_frisk/utils.cljs
@@ -44,12 +44,12 @@
 
 (defn normalize-draggable [x]
   (when x
-    (cond (< x 80) 80
+    (cond (< x 30) 30
           (> x (- js/window.innerWidth 30)) (- js/window.innerWidth 30)
           :else x)))
 
-(defn closed? [left]
-  (= left (- js/window.innerWidth 30)))
+(defn closed? [width]
+  (= 30 width))
 
 (defn str-ms [value]
   (when-not (string/blank? value)


### PR DESCRIPTION
By using right: 0px and width: x the panel is always relative to the right corner of the viewport, so when resizing browser viewport (window, dev tool etc.) re-frisk panel follows the right corner automatically.

Fixes #84

Note: There is still somewhat separate issue, that there is always 100% height 30px div that catches all the mouse events. I believe the toggle buttons should be positioned outside of such div, so that re-frisk doesn't prevent clicking on the application anywhere but on the buttons. I might try to fix this still.

If you choose to merge this, I'd like a new 1.6 release also.